### PR TITLE
Add support for Slim 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ deploy:
   file: "Slim_Framework.tgz"
   skip_cleanup: true
   on:
-    condition: $TRAVIS_EVENT_TYPE = cron
+    condition: ($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron)

--- a/rebuild.py
+++ b/rebuild.py
@@ -6,7 +6,7 @@ import copy, os, re, sqlite3, string, urllib.request, urllib.parse, urllib.error
 from bs4 import BeautifulSoup, NavigableString, Tag
 
 DOCUMENTS_DIR = os.path.join('Slim_Framework.docset', 'Contents', 'Resources', 'Documents')
-HTML_DIR = os.path.join('www.slimframework.com/docs')
+HTML_DIR = os.path.join('www.slimframework.com/docs/v4')
 
 db = sqlite3.connect('Slim_Framework.docset/Contents/Resources/docSet.dsidx')
 cur = db.cursor()
@@ -91,6 +91,12 @@ for root, dirs, files in os.walk(os.path.join(DOCUMENTS_DIR, HTML_DIR), topdown=
             if "href" in a.attrs and test.match(a["href"].strip()):
                 a.extract()
 
+        for a in soup.find_all("a"):
+            test = re.compile("^https?.*cdn.jsdelivr.*", re.IGNORECASE)
+
+            if "href" in a.attrs and test.match(a["href"].strip()):
+                a.extract()
+
         # remove header navbar with blog link
         try:
             soup.find('nav', class_='navbar-fixed-top').decompose()
@@ -111,10 +117,10 @@ for root, dirs, files in os.walk(os.path.join(DOCUMENTS_DIR, HTML_DIR), topdown=
             soup.find('button', class_='dropdown-toggle').parent.decompose()
         except AttributeError:
             pass
-        # remove link to v2 docs
+        # remove link to v3 docs
         try:
             for alert in soup.find_all('div', class_='alert-info'):
-                if 'Slim 2 Docs' in str(alert):
+                if 'Slim 3 Docs' in str(alert):
                     alert.decompose()
         except (AttributeError, TypeError):
             pass

--- a/sync.sh
+++ b/sync.sh
@@ -2,12 +2,11 @@
 
 rm -rf Slim_Framework.docset/Contents/Resources
 
-httrack http://www.slimframework.com/docs/ \
+httrack https://www.slimframework.com/docs/v4 \
   -O Slim_Framework.docset/Contents/Resources/Documents,cache -I0 \
   --display=2 --timeout=60 --retries=99 --sockets=7 \
   --connection-per-second=5 --max-rate=250000 \
   --keep-alive --depth=5 --mirror --clean --robots=0 \
   --user-agent '$(httrack --version); dash-slimframework ()' \
-  "-*" "+www.slimframework.com/docs" \
-  "+www.slimframework.com/docs/v3" "+www.slimframework.com/docs/v3/*" \
+  "-www.slimframework.com/docs/v2" "-www.slimframework.com/docs/v3" \
   "+www.slimframework.com/assets/*" "+maxcdn.bootstrapcdn.com/font-awesome/*"


### PR DESCRIPTION
As you may know, Slim 4 was recently released. Automatic builds detected this correctly, but documentation URLs have changed, so build failed. I'm now creating a fix for support for Slim 4.

@pfefferle This contains just modifications required to build Slim 4 docset. To actually built it, you can either [trigger build](https://blog.travis-ci.com/2017-08-24-trigger-custom-build) from web UI (I added support for this in this PR) or wait until next cron restarts.